### PR TITLE
Fixed issue with Conflicting compression options

### DIFF
--- a/lib/apple_epf/extractor.rb
+++ b/lib/apple_epf/extractor.rb
@@ -21,7 +21,7 @@ module AppleEpf
       end
 
       result = if AppleEpf.use_lbzip2
-        system "cd #{@dirname} && tar -xj #{@basename} #{@extracted_files.join(' ')} --use-compress-program lbzip2"
+        system "cd #{@dirname} && tar -xf #{@basename} #{@extracted_files.join(' ')} --use-compress-program lbzip2"
       else
         system "cd #{@dirname} && tar -xjf #{@basename} #{@extracted_files.join(' ')} "
       end


### PR DESCRIPTION
Using `-xj` would produce a `tar: Conflicting compression options` error.